### PR TITLE
Fix: Vtoyboot installation in Arch Linux with systemd-based initramfs

### DIFF
--- a/vtoyboot-1.0.36/distros/mkinitcpio/check-dependencies.sh
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/check-dependencies.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Dependency checker for Ventoy mkinitcpio systemd support
+
+echo "=== Checking Dependencies for Ventoy mkinitcpio systemd support ==="
+echo ""
+
+missing=0
+
+# Check required packages
+echo "Checking required packages:"
+
+if pacman -Q lvm2 >/dev/null 2>&1; then
+    echo "  ✓ lvm2 (provides dmsetup)"
+else
+    echo "  ✗ lvm2 - MISSING (provides dmsetup)"
+    echo "    Install: sudo pacman -S lvm2"
+    missing=1
+fi
+
+# Check for awk (multiple providers)
+if command -v awk >/dev/null 2>&1; then
+    awk_provider=$(pacman -Qo $(which awk) 2>/dev/null | awk '{print $5}')
+    echo "  ✓ awk (provided by $awk_provider)"
+else
+    echo "  ✗ awk - MISSING"
+    echo "    Install: sudo pacman -S gawk (or busybox)"
+    missing=1
+fi
+
+if command -v grep >/dev/null 2>&1; then
+    echo "  ✓ grep"
+else
+    echo "  ✗ grep - MISSING"
+    echo "    Install: sudo pacman -S grep"
+    missing=1
+fi
+
+echo ""
+echo "Checking required binaries in PATH:"
+
+for binary in dmsetup vtoydump vtoypartx vtoytool awk grep which; do
+    if command -v $binary >/dev/null 2>&1; then
+        echo "  ✓ $binary: $(which $binary)"
+    else
+        echo "  ✗ $binary - NOT FOUND"
+        missing=1
+    fi
+done
+
+echo ""
+echo "Checking systemd files:"
+
+if [ -f /usr/lib/initcpio/install/ventoy ]; then
+    echo "  ✓ /usr/lib/initcpio/install/ventoy"
+else
+    echo "  ✗ /usr/lib/initcpio/install/ventoy - NOT FOUND"
+fi
+
+if [ -f /usr/lib/initcpio/hooks/ventoy ]; then
+    echo "  ✓ /usr/lib/initcpio/hooks/ventoy"
+else
+    echo "  ✗ /usr/lib/initcpio/hooks/ventoy - NOT FOUND"
+fi
+
+if [ -f /usr/lib/initcpio/ventoy-device-mapper ]; then
+    echo "  ✓ /usr/lib/initcpio/ventoy-device-mapper"
+    if [ -x /usr/lib/initcpio/ventoy-device-mapper ]; then
+        echo "    ✓ Executable"
+    else
+        echo "    ✗ Not executable (should be 755)"
+    fi
+else
+    echo "  ✗ /usr/lib/initcpio/ventoy-device-mapper - NOT FOUND"
+fi
+
+if [ -f /usr/lib/systemd/system/ventoy-device-mapper.service ]; then
+    echo "  ✓ /usr/lib/systemd/system/ventoy-device-mapper.service"
+else
+    echo "  ✗ /usr/lib/systemd/system/ventoy-device-mapper.service - NOT FOUND"
+fi
+
+echo ""
+if [ $missing -eq 0 ]; then
+    echo "✅ All dependencies satisfied"
+	[ -n "1" ]
+else
+    echo "❌ Some dependencies are missing"
+    echo ""
+    echo "To install missing dependencies:"
+    echo "  sudo pacman -S lvm2 gawk grep"
+    exit 1
+fi

--- a/vtoyboot-1.0.36/distros/mkinitcpio/check.sh
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/check.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+#************************************************************************************
+# Copyright (c) 2020, longpanda <admin@ventoy.net>
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# 
+#************************************************************************************
+
+vtoy_check_mkinitcpio() {
+    if command -v mkinitcpio >/dev/null 2>&1; then
+        
+		for vtfile in '/etc/mkinitcpio.conf' '/usr/lib/initcpio/install/lvm2'; do
+			if ! [ -f $vtfile ]; then
+				[ -z "1" ]; return
+			fi
+		done
+        
+        [ -n "1" ]
+    else
+        [ -z "1" ]
+    fi
+}

--- a/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-device-mapper
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-device-mapper
@@ -1,0 +1,143 @@
+#!/usr/bin/ash
+# Ventoy Device Mapper Script for systemd initrd
+# This script creates device-mapper devices for Ventoy virtual disks
+
+ventoy_check_efivars() {
+    if [ -e /sys/firmware/efi ]; then
+        if grep -q efivar /proc/mounts; then
+            :
+        else
+            if [ -e /sys/firmware/efi/efivars ]; then
+                mount -t efivarfs efivarfs /sys/firmware/efi/efivars >/dev/null 2>&1
+            fi
+        fi
+    fi
+}
+
+ventoy_log() {
+    echo "$@" >> /tmp/vtoy.log
+    echo "$@"
+}
+
+ventoy_dm_create_ventoy() {
+    dmsetup create ventoy /ventoy_table || return 1
+
+    RAWDISKNAME=$(head -n1 /ventoy_table | awk '{print $4}')
+    RAWDISKSHORT=${RAWDISKNAME#/dev/}
+
+    if [ -f /sys/class/block/$RAWDISKSHORT/size ]; then
+        RAWDISKSECS=$(cat /sys/class/block/$RAWDISKSHORT/size)
+        echo "0 $RAWDISKSECS linear $RAWDISKNAME 0" > /ventoy_raw_table
+        dmsetup create $RAWDISKSHORT /ventoy_raw_table
+    fi
+
+    return 0
+}
+
+vtoy_wait_for_device() {
+    i=100
+
+    while [ $i -gt 0 ]; do
+        if vtoydump > /dev/null 2>&1; then
+            break
+        else
+            sleep 0.2
+        fi
+        i=$((i - 1))
+    done
+}
+
+vtoy_device_mapper_proc() {
+    ventoy_log "Starting Ventoy device mapper..."
+
+    # Flush multipath before dmsetup
+    if which multipath >/dev/null 2>&1; then
+        multipath -F > /dev/null 2>&1
+    fi
+
+    vtoydump -L > /ventoy_table || {
+        ventoy_log "ERROR: vtoydump -L failed"
+        return 1
+    }
+
+    if ventoy_dm_create_ventoy; then
+        ventoy_log "Device mapper created successfully"
+    else
+        ventoy_log "First attempt failed, retrying..."
+        sleep 3
+        if which multipath >/dev/null 2>&1; then
+            multipath -F > /dev/null 2>&1
+        fi
+        ventoy_dm_create_ventoy || {
+            ventoy_log "ERROR: Failed to create device mapper"
+            return 1
+        }
+    fi
+
+    DEVDM=/dev/mapper/ventoy
+
+    loop=0
+    while [ ! -e $DEVDM ]; do
+        sleep 0.5
+        loop=$((loop + 1))
+        if [ $loop -gt 10 ]; then
+            ventoy_log "Waiting for ventoy device ... (attempt $loop)"
+        fi
+
+        if [ $loop -gt 10 ] && [ $loop -lt 15 ]; then
+            if which multipath >/dev/null 2>&1; then
+                multipath -F > /dev/null 2>&1
+            fi
+            ventoy_dm_create_ventoy
+        fi
+
+        if [ $loop -gt 40 ]; then
+            ventoy_log "ERROR: Timeout waiting for $DEVDM"
+            return 1
+        fi
+    done
+
+    ventoy_log "Ventoy device $DEVDM created"
+
+    # Create partition mappings
+    for ID in $(vtoypartx $DEVDM -oNR 2>/dev/null | grep -v NR); do
+        PART_START=$(vtoypartx $DEVDM -n$ID -oSTART,SECTORS 2>/dev/null | grep -v START | awk '{print $1}')
+        PART_SECTOR=$(vtoypartx $DEVDM -n$ID -oSTART,SECTORS 2>/dev/null | grep -v START | awk '{print $2}')
+
+        if [ -n "$PART_START" ] && [ -n "$PART_SECTOR" ]; then
+            echo "0 $PART_SECTOR linear $DEVDM $PART_START" > /ventoy_part_table
+            if dmsetup create ventoy$ID /ventoy_part_table 2>/dev/null; then
+                ventoy_log "Created partition mapping: /dev/mapper/ventoy$ID"
+            else
+                ventoy_log "WARNING: Failed to create ventoy$ID"
+            fi
+        fi
+    done
+
+    rm -f /ventoy_table
+    rm -f /ventoy_part_table
+    rm -f /ventoy_raw_table
+
+    # Trigger udev to process new devices
+    if which udevadm >/dev/null 2>&1; then
+        udevadm trigger --subsystem-match=block 2>/dev/null || true
+        udevadm settle --timeout=10 2>/dev/null || true
+    fi
+
+    ventoy_log "Ventoy device mapper setup completed"
+    return 0
+}
+
+# Main execution
+ventoy_check_efivars
+
+if vtoydump -c >/dev/null 2>/dev/null; then
+    vtoy_wait_for_device
+    if vtoydump > /dev/null 2>&1; then
+        vtoy_device_mapper_proc
+        exit 0
+    fi
+fi
+
+ventoy_log "No Ventoy boot detected, skipping device mapper"
+exit 0

--- a/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-device-mapper.service
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-device-mapper.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Ventoy Device Mapper Setup
+DefaultDependencies=no
+Wants=systemd-udevd.service
+After=systemd-udevd.service
+Before=initrd-root-device.target
+Before=sysroot.mount
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/initcpio/ventoy-device-mapper
+
+[Install]
+WantedBy=initrd.target

--- a/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-hook.sh
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-hook.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/ash
+#************************************************************************************
+# Copyright (c) 2020, longpanda <admin@ventoy.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#************************************************************************************
+
+###########################
+###########################
+#AUTO_INSERT_COMMON_FUNC
+
+ventoy_check_efivars() {
+    if [ -e /sys/firmware/efi ]; then
+        if grep -q efivar /proc/mounts; then
+            :
+        else
+            if [ -e /sys/firmware/efi/efivars ]; then
+                mount -t efivarfs efivarfs /sys/firmware/efi/efivars  >/dev/null 2>&1
+            fi
+        fi
+    fi
+}
+
+ventoy_log() {
+    echo "$@" >> /tmp/vtoy.log
+}
+
+
+ventoy_check_insmod() {
+    if [ -f /bin/kmod ]; then
+        [ -f /bin/insmod ] || ln -s /bin/kmod /bin/insmod
+        [ -f /bin/lsmod ]  || ln -s /bin/kmod /bin/lsmod
+    fi
+}
+
+ventoy_dm_create_ventoy() {
+    dmsetup create ventoy /ventoy_table
+
+    RAWDISKNAME=$(head -n1 /ventoy_table | awk '{print $4}')
+    RAWDISKSHORT=${RAWDISKNAME#/dev/}
+    RAWDISKSECS=$(cat /sys/class/block/$RAWDISKSHORT/size)
+
+    echo "0 $RAWDISKSECS linear $RAWDISKNAME 0" > /ventoy_raw_table
+    dmsetup create $RAWDISKSHORT  /ventoy_raw_table
+
+    vret=$?
+    return $vret
+}
+
+
+vtoy_wait_for_device() {
+    i=100
+
+    while [ $i -gt 0 ]; do
+        if vtoydump > /dev/null 2>&1; then
+            break
+        else
+            sleep 0.2
+        fi
+        i=$((i - 1))
+    done
+}
+
+vtoy_device_mapper_proc() {
+    #flush multipath before dmsetup
+    multipath -F > /dev/null 2>&1
+
+    vtoydump -L > /ventoy_table
+    if ventoy_dm_create_ventoy; then
+        :
+    else
+        sleep 3
+        multipath -F > /dev/null 2>&1
+        ventoy_dm_create_ventoy
+    fi
+
+    DEVDM=/dev/mapper/ventoy
+
+    loop=0
+    while [ ! -e $DEVDM ]; do
+        sleep 0.5
+        loop=$((loop + 1))
+        if [ $loop -gt 10 ]; then
+            echo "Waiting for ventoy device ..." > /dev/console
+        fi
+
+        if [ $loop -gt 10 ] && [ $loop -lt 15 ]; then
+            multipath -F > /dev/null 2>&1
+            ventoy_dm_create_ventoy
+        fi
+    done
+
+    for ID in $(vtoypartx $DEVDM -oNR | grep -v NR); do
+        PART_START=$(vtoypartx  $DEVDM -n$ID -oSTART,SECTORS | grep -v START | awk '{print $1}')
+        PART_SECTOR=$(vtoypartx $DEVDM -n$ID -oSTART,SECTORS | grep -v START | awk '{print $2}')
+
+        echo "0 $PART_SECTOR linear $DEVDM $PART_START" > /ventoy_part_table
+        dmsetup create ventoy$ID /ventoy_part_table
+    done
+
+    rm -f /ventoy_table
+    rm -f /ventoy_part_table
+}
+
+run_hook() {
+    #check for efivarfs
+    ventoy_check_efivars
+
+    if vtoydump -c >/dev/null 2>/dev/null; then
+        vtoy_wait_for_device
+        if vtoydump > /dev/null 2>&1; then
+            vtoy_device_mapper_proc
+        fi
+    fi
+}
+
+

--- a/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-install.sh
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/ventoy-install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#************************************************************************************
+# Copyright (c) 2020, longpanda <admin@ventoy.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+#************************************************************************************
+
+build() {
+    add_binary "dd"
+    add_binary "sort"
+    add_binary "head"
+    add_binary "find"
+    add_binary "xzcat"
+    add_binary "zcat"
+    add_binary "basename"
+    add_binary "vtoydump"
+    add_binary "vtoypartx"
+    add_binary "vtoytool"
+
+    # Add essential tools needed by the ventoy device mapper script
+    add_binary "dmsetup"
+    add_binary "awk"
+    add_binary "grep"
+
+    for md in $(cat /sbin/vtoydrivers 2>/dev/null); do
+        if [ -n "$md" ]; then
+            if modinfo -n $md 2>/dev/null | grep -q '\.ko'; then
+                add_module $md
+            fi
+        fi
+    done
+
+    # Check if systemd hook is present
+    local use_systemd=0
+    for hook in "${HOOKS[@]}"; do
+        if [ "$hook" = "systemd" ]; then
+            use_systemd=1
+            break
+        fi
+    done
+
+    if [ $use_systemd -eq 1 ]; then
+        # Using systemd - install service unit and executable script
+
+        # Add the service unit to initramfs (file should already be in /usr/lib/systemd/system/)
+        add_systemd_unit "ventoy-device-mapper.service"
+
+        # Add the device mapper script with explicit 755 mode to ensure it's executable
+        add_file "/usr/lib/initcpio/ventoy-device-mapper" "/usr/lib/initcpio/ventoy-device-mapper" "755"
+
+        # Enable the service by creating symlink
+        add_symlink "/usr/lib/systemd/system/initrd.target.wants/ventoy-device-mapper.service" \
+                    "../ventoy-device-mapper.service"
+    else
+        # Using traditional busybox/udev initramfs - use runtime hook
+        add_runscript
+    fi
+}
+
+help() {
+  cat <<HELPEOF
+This hook enables ventoy device mapper in initramfs.
+
+For systemd-based initramfs, it installs a systemd service that runs before
+root device detection. For traditional busybox/udev initramfs, it uses the
+standard runtime hook mechanism.
+
+The hook automatically detects which mode to use based on the presence
+of the 'systemd' hook in the HOOKS array.
+HELPEOF
+}

--- a/vtoyboot-1.0.36/distros/mkinitcpio/vtoy.sh
+++ b/vtoyboot-1.0.36/distros/mkinitcpio/vtoy.sh
@@ -1,0 +1,137 @@
+#!/bin/sh
+#************************************************************************************
+# Copyright (c) 2020, longpanda <admin@ventoy.net>
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# 
+#************************************************************************************
+
+. ./tools/efi_legacy_grub.sh
+
+vtoy_clean_env() {
+    rm -f /sbin/vtoydump  /sbin/vtoypartx  /sbin/vtoytool  /sbin/vtoydrivers
+    rm -f /usr/lib/initcpio/hooks/ventoy
+    rm -f /usr/lib/initcpio/install/ventoy
+    rm -f /usr/lib/initcpio/ventoy-device-mapper
+    rm -f /usr/lib/systemd/system/ventoy-device-mapper.service
+}
+print_init_param_warning() {
+    echo -e "\033[33mWhen manually modifying hooks in /etc/mkinitcpio.conf, ventoy must be put after systemd (if enabled).\033[0m"
+    sleep 1
+}
+
+print_kernel_param_warning() {
+    echo ""
+    echo -e "\033[33m[WARNING] ################################################################## \033[0m"
+    for i in 0 1 2 3 4 5 6 7 8 9; do
+        echo -e "\033[33m[WARNING] !!!! Do NOT use root=PARTUUID/PARTLABEL/gpt-auto/dissect   !!!! \033[0m"
+    done
+    echo -e "\033[33m[WARNING] ################################################################## \033[0m"
+    echo ""
+    echo -e "\033[33mVentoy device mapper does NOT expose GPT partition type metadata.\033[0m"
+    echo -e "\033[33mThe following kernel parameters will FAIL to boot:\033[0m"
+    echo -e "\033[33m  - root=PARTUUID=xxx\033[0m"
+    echo -e "\033[33m  - root=PARTLABEL=xxx\033[0m"
+    echo -e "\033[33m  - root=gpt-auto\033[0m"
+    echo -e "\033[33m  - root=dissect\033[0m"
+    echo ""
+    echo -e "\033[32mUse these instead (they work correctly):\033[0m"
+    echo -e "\033[32m  - root=LABEL=xxx       (recommended)\033[0m"
+    echo -e "\033[32m  - root=UUID=xxx        (recommended)\033[0m"
+    echo -e "\033[32m  - root=/dev/mapper/ventoyN\033[0m"
+    echo ""
+    echo -e "\033[33mCheck your bootloader config (systemd-boot, GRUB, etc.) and update\033[0m"
+    echo -e "\033[33mthe kernel command line accordingly.\033[0m"
+    echo ""
+    sleep 5
+}
+
+vtoy_clean_env
+
+cp -a $vtdumpcmd /sbin/vtoydump
+cp -a $partxcmd  /sbin/vtoypartx
+cp -a $vtoytool  /sbin/vtoytool
+cp -a ./tools/vtoydrivers /sbin/vtoydrivers
+cp -a ./distros/$initrdtool/ventoy-install.sh  /usr/lib/initcpio/install/ventoy
+cp -a ./distros/$initrdtool/ventoy-hook.sh  /usr/lib/initcpio/hooks/ventoy
+
+# Copy systemd-related files if they exist
+if [ -f ./distros/$initrdtool/ventoy-device-mapper ]; then
+    install -Dm755 ./distros/$initrdtool/ventoy-device-mapper /usr/lib/initcpio/ventoy-device-mapper
+fi
+
+if [ -f ./distros/$initrdtool/ventoy-device-mapper.service ]; then
+    install -Dm644 ./distros/$initrdtool/ventoy-device-mapper.service /usr/lib/systemd/system/ventoy-device-mapper.service
+fi
+
+# Print warning about kernel parameters
+print_init_param_warning
+print_kernel_param_warning
+
+echo "updating the initramfs, please wait ..."
+
+if ! grep -q '^HOOKS=.*ventoy' /etc/mkinitcpio.conf; then
+    if grep -q '^HOOKS=.*lvm' /etc/mkinitcpio.conf; then
+        exthook='ventoy'
+    else
+        exthook='lvm2 ventoy'
+    fi
+
+    if grep -q '^HOOKS=.*encrypt' /etc/mkinitcpio.conf; then
+        sed "s/\(^HOOKS=.*\)encrypt/\1 $exthook encrypt/" -i /etc/mkinitcpio.conf
+    elif grep -q "^HOOKS=\"" /etc/mkinitcpio.conf; then    
+        sed "s/^HOOKS=\"\(.*\)\"/HOOKS=\"\1 $exthook\"/" -i /etc/mkinitcpio.conf
+    elif grep -q "^HOOKS=(" /etc/mkinitcpio.conf; then    
+        sed "s/^HOOKS=(\(.*\))/HOOKS=(\1 $exthook)/" -i /etc/mkinitcpio.conf
+    fi
+fi
+
+mkinitcpio -P
+
+disable_grub_os_probe
+
+#wrapper grub-probe
+echo "grub mkconfig ..."
+PROBE_PATH=$(find_grub_probe_path)
+MKCONFIG_PATH=$(find_grub_mkconfig_path)
+echo "PROBE_PATH=$PROBE_PATH MKCONFIG_PATH=$MKCONFIG_PATH"
+
+if [ -e "$PROBE_PATH" -a -e "$MKCONFIG_PATH" ]; then
+    wrapper_grub_probe $PROBE_PATH
+    
+    GRUB_CFG_PATH=$(find_grub_config_path)
+    if [ -f "$GRUB_CFG_PATH" ]; then
+        echo "$MKCONFIG_PATH -o $GRUB_CFG_PATH"
+        $MKCONFIG_PATH -o $GRUB_CFG_PATH
+    else
+        echo "$MKCONFIG_PATH null"
+        $MKCONFIG_PATH > /dev/null 2>&1
+    fi
+fi
+
+
+if [ -e /sys/firmware/efi ]; then
+    if [ -e /dev/mapper/ventoy ]; then
+        echo "This is ventoy enviroment"
+    else
+        update_grub_config
+        install_legacy_bios_grub
+    fi
+    
+    if [ "$1" = "-s" ]; then
+        recover_shim_efi
+    else
+        replace_shim_efi
+    fi
+fi

--- a/vtoyboot-1.0.36/vtoyboot.sh
+++ b/vtoyboot-1.0.36/vtoyboot.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+#************************************************************************************
+# Copyright (c) 2020, longpanda <admin@ventoy.net>
+# 
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 3 of the
+# License, or (at your option) any later version.
+# 
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+# 
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+# 
+#************************************************************************************
+
+vtoy_version=1.0.36
+
+if echo "$*" | grep -q __vtoyloop__; then
+    :
+else
+    if readlink /proc/$$/exe | grep -q dash; then
+        exec /bin/bash $0 $* __vtoyloop__
+    fi
+fi
+
+vtoy_get_initrdtool_type() {  
+    . ./distros/initramfstool/check.sh
+    . ./distros/mkinitcpio/check.sh
+    . ./distros/dracut/check.sh
+
+    if vtoy_check_initramfs_tool; then
+        echo 'initramfstool'; return
+    elif vtoy_check_mkinitcpio; then
+        echo 'mkinitcpio'; return
+    elif vtoy_check_dracut; then
+        echo 'dracut'; return
+    else
+        echo 'unknown'; return
+    fi
+}
+
+echo ''
+echo '**********************************************'
+echo "      vtoyboot $vtoy_version"
+echo "      longpanda admin@ventoy.net"
+echo "      https://www.ventoy.net"
+echo '**********************************************'
+echo ''
+
+USER=$(whoami)
+if [ "$USER" != "root" ]; then
+    echo "Please run this script as root or use sudo"
+    echo ""
+    exit 1
+fi
+
+if ! [ -d ./distros ]; then
+    echo "Please run the script in the right directory"
+    echo ""
+    exit 1
+fi
+
+if [ -e /dev/mapper/ventoy ]; then
+    :
+else    
+    if ls -1 /dev | grep -q '[svh]db$'; then
+        echo "More than one disks found. Currently only one disk is supported."
+        echo ""
+        exit 1
+    fi
+fi
+
+initrdtool=$(vtoy_get_initrdtool_type)
+
+if ! [ -f ./distros/$initrdtool/vtoy.sh ]; then
+    echo 'Current OS is not supported!'
+    exit 1
+fi
+
+if [ $initrdtool = "mkinitcpio" ]; then
+    . ./distros/$initrdtool/check-dependencies.sh
+fi
+
+vtoyboot_need_proc_ibt() {
+    vtTool=$1
+    vtKv=$(uname -r)
+    vtMajor=$(echo $vtKv | awk -F. '{print $1}')
+    vtMinor=$(echo $vtKv | awk -F. '{print $2}')
+    
+    #ibt was supported since linux kernel 5.18
+    if [ $vtMajor -lt 5 ]; then
+        false; return
+    elif [ $vtMajor -eq 5 ]; then
+        if [ $vtMajor -lt 18 ]; then
+            false; return
+        fi
+    fi
+    
+    if grep -q ' ibt=off' /proc/cmdline; then
+        false; return
+    fi
+
+    #hardware CPU doesn't support IBT
+    if $vtTool vtoykmod -I; then
+        :
+    else
+        false; return
+    fi
+    
+    #dot.CONFIG not enabled
+    if grep -q ' ibt_restore$' /proc/kallsyms; then
+        :
+    else
+        false; return
+    fi
+    
+    true
+}
+
+#prepare vtoydump
+if uname -a | grep -Eq "x86_64|amd64"; then
+    vtdumpcmd=./tools/vtoydump64
+    partxcmd=./tools/vtoypartx64
+    vtcheckcmd=./tools/vtoycheck64
+    vtoytool=./tools/vtoytool_64
+elif uname -a | grep -Eq "aarch64|arm64"; then
+    vtdumpcmd=./tools/vtoydumpaa64
+    partxcmd=./tools/vtoypartxaa64
+    vtcheckcmd=./tools/vtoycheckaa64
+    vtoytool=./tools/vtoytool_aa64
+else
+    vtdumpcmd=./tools/vtoydump32
+    partxcmd=./tools/vtoypartx32
+    vtcheckcmd=./tools/vtoycheck32
+    vtoytool=./tools/vtoytool_32
+fi
+
+chmod +x $vtdumpcmd $partxcmd $vtcheckcmd
+
+for vsh in $(ls ./distros/$initrdtool/*.sh); do
+    chmod +x $vsh
+done
+
+echo "Current system use $initrdtool as initramfs tool"
+. ./distros/$initrdtool/vtoy.sh "$@"
+if [ $? -eq 0 ]; then
+    sync
+    echo ""
+    echo "vtoyboot process successfully finished."
+    echo ""
+else
+    echo ""
+    echo "vtoyboot process failed, please check."
+    echo ""
+    exit 1
+fi


### PR DESCRIPTION
Fixes #120, #121, ventoy/Ventoy#3271, ventoy/Ventoy#3503, etc.

- Auto-detect systemd vs traditional initramfs
- Add systemd service unit for proper device mapper timing
- Check missing dependencies (dmsetup, awk, grep, which)
- Fully backward compatible with traditional initramfs

This enables Ventoy to boot Arch Linux virtual disks when using
systemd-based initramfs, which is becoming increasingly common.
The fix is fully backward compatible and auto-detects the
initramfs type.

Tested in the minimal Arch Linux install by `archinstall`(with systemd-boot), with UEFI boot mode.	